### PR TITLE
Adjust the telegraf cribl-edge output port

### DIFF
--- a/telemetry/telegraf/telegraf.conf
+++ b/telemetry/telegraf/telegraf.conf
@@ -4,4 +4,4 @@
   service_address = ":57000"
 
 [[outputs.opentelemetry]]
-  service_address = "http://192.133.187.53:9420"
+  service_address = "http://192.133.187.53:4317"


### PR DESCRIPTION
I think the port is supposed to be 4317 here.  I had to adjust this to get the metrics into Cribl from Telegraf.